### PR TITLE
Re-evaluate the pathmap if there's a recovery variant in play

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -164,6 +164,11 @@ endif
 TARGET_DEVICE_DIR := $(patsubst %/,%,$(dir $(board_config_mk)))
 board_config_mk :=
 
+## Rebuild the pathmap if there's a recovery variant. Its path probably changed
+ifneq ($(RECOVERY_VARIANT),)
+include $(BUILD_SYSTEM)/pathmap.mk
+endif
+
 # Perhaps we should move this block to build/core/Makefile,
 # once we don't have TARGET_NO_KERNEL reference in AndroidBoard.mk/Android.mk.
 ifneq ($(strip $(TARGET_NO_BOOTLOADER)),true)


### PR DESCRIPTION
Chances are the recovery location has changed, so rebuild the pathmap
to compensate. This lets the variable be defined in BoardConfig files
instead of the global environment

Change-Id: I87c23a452656ffa7817711796c17f79e30465756
