### PR TITLE
Revert "Add handheld_core_hardware.xml to telephony base"

### DIFF
--- a/target/product/full_base_telephony.mk
+++ b/target/product/full_base_telephony.mk
@@ -22,8 +22,5 @@
 PRODUCT_PROPERTY_OVERRIDES := \
     keyguard.no_require_sim=true
 
-PRODUCT_COPY_FILES := \
-    frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml
-
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)


### PR DESCRIPTION
Don't do this. handheld_core_hardware.xml includes feature declarations
that aren't mandatory, particularly cameras and magnetometers, but also
things like managed users. According to the CDD, these are optional.
Go back to the pre-L mechanism of including the declarations per-device
to make them accurate.
This reverts commit dccce7bbe9673d4b8ce1a3559182767f926e1ff8.

Conflicts:
    target/product/full_base_telephony.mk

Change-Id: I6db55082295171b78fe595e783799ee54458c4fd
